### PR TITLE
DeadlyReentry, RealChute, Kerbalism and FerramAerospaceResearch

### DIFF
--- a/GameData/RationalHydroDynamics/RationalBuoyancy.cfg
+++ b/GameData/RationalHydroDynamics/RationalBuoyancy.cfg
@@ -346,11 +346,11 @@
 {
 	@buoyancy += 0.3
 }
-@PART:HAS[@MODULE[ModuleControlSurface],#rationalBuoyancy]:FOR[00RationalBuoyancy]
+@PART:HAS[@MODULE[ModuleControlSurface],#rationalBuoyancy]:NEEDS[FerramAerospaceResearch]:FOR[00RationalBuoyancy]
 {
 	@buoyancy += 0.3
 }
-@PART:HAS[@MODULE[FARControllableSurface],#category[Engine],#rationalBuoyancy]:NEEDS[FerramAerospaceResearch]:FOR[00RationalBuoyancy]
+@PART:HAS[@MODULE[ModuleControlSurface],#category[Engine],#rationalBuoyancy]:FOR[00RationalBuoyancy]
 {
 	@buoyancy -= 0.15
 }

--- a/GameData/RationalHydroDynamics/RationalBuoyancy.cfg
+++ b/GameData/RationalHydroDynamics/RationalBuoyancy.cfg
@@ -322,6 +322,10 @@
 {
 	@buoyancy += 0.3
 }
+@PART:HAS[@MODULE[FARWingAerodynamicModel],~CrewCapacity[>0],#rationalBuoyancy]:NEEDS[FerramAerospaceResearch]:FOR[00RationalBuoyancy]
+{
+	@buoyancy += 0.3
+}
 @PART:HAS[@MODULE[ModuleLiftingSurface],#category[Engine],#rationalBuoyancy]:FOR[00RationalBuoyancy]
 {
 	@buoyancy -= 0.15
@@ -342,7 +346,11 @@
 {
 	@buoyancy += 0.3
 }
-@PART:HAS[@MODULE[ModuleControlSurface],#category[Engine],#rationalBuoyancy]:FOR[00RationalBuoyancy]
+@PART:HAS[@MODULE[ModuleControlSurface],#rationalBuoyancy]:FOR[00RationalBuoyancy]
+{
+	@buoyancy += 0.3
+}
+@PART:HAS[@MODULE[FARControllableSurface],#category[Engine],#rationalBuoyancy]:NEEDS[FerramAerospaceResearch]:FOR[00RationalBuoyancy]
 {
 	@buoyancy -= 0.15
 }

--- a/GameData/RationalHydroDynamics/RationalBuoyancy.cfg
+++ b/GameData/RationalHydroDynamics/RationalBuoyancy.cfg
@@ -239,6 +239,10 @@
 {
 	@buoyancy += 0.5
 }
+@PART:HAS[#category[Utility],@MODULE[RealChuteModule],#rationalBuoyancy]:NEEDS[RealChute]:FOR[00RationalBuoyancy]
+{
+	@buoyancy += 0.5
+}
 @PART:HAS[#category[Utility],@RESOURCE[*]:HAS[#maxAmount[>100]],#rationalBuoyancy]:FOR[00RationalBuoyancy]
 {
 	@buoyancy += 0.15 
@@ -284,6 +288,10 @@
 	rationalBuoyancy = Yes
 }
 @PART:HAS[#category[Thermal],@RESOURCE[Ablator]]:FOR[00RationalBuoyancy]
+{
+	@buoyancy -= 0.1
+}
+@PART:HAS[#category[Thermal],@RESOURCE[AblativeShielding]]:NEEDS[DeadlyReentry]:FOR[00RationalBuoyancy]
 {
 	@buoyancy -= 0.1
 }
@@ -415,6 +423,12 @@
 {
 	%buoyancy = 1
 	%rationalBuoyancy = Yes
+}
+
+// Kerbalism
+@PART:HAS[@MODULE[ProcessController]:HAS[#resource[_PressureControl],#running[?rue]],#rationalBuoyancy]:NEEDS[KerbalismDefault,ProfileDefault]:FOR[00RationalBuoyancy]
+{
+	@buoyancy += 0.1
 }
 
 


### PR DESCRIPTION
As the comparision down below on this PR does not really show the single differences but the left side whole red and the right side whole green, I list my changes here:

Just added

to Thermal:
```
@PART:HAS[#category[Thermal],@RESOURCE[AblativeShielding]]:NEEDS[DeadlyReentry]:FOR[00RationalBuoyancy]
{
	@buoyancy -= 0.1
}

```
to Utility:
```
@PART:HAS[#category[Utility],@MODULE[RealChuteModule],#rationalBuoyancy]:NEEDS[RealChute]:FOR[00RationalBuoyancy]
{
	@buoyancy += 0.5
}

```
to Plugin mods:
```
// Kerbalism
@PART:HAS[@MODULE[ProcessController]:HAS[#resource[_PressureControl],#running[?rue]],#rationalBuoyancy]:NEEDS[KerbalismDefault,ProfileDefault]:FOR[00RationalBuoyancy]
{
	@buoyancy += 0.1
}

```